### PR TITLE
fix: enigma depend_on tangerine & macksnow

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,9 @@ services:
     image: nginx:latest
     volumes:
       - ./src/enigma/default.conf:/etc/nginx/conf.d/default.conf:cached
+    depends_on:
+      - macksnow
+      - tangerine
     ports:
       - 80:80
 


### PR DESCRIPTION
enigmaがmacksnowとtangerin（こちらは再現してないけど）のコンテナ生成を待たずに起動してしまい名前解決に失敗して落ちる問題があったのを解決