### PR TITLE
Feat/improvement heroku auto deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ RUN apk add \
     git \
     nginx
 
+# https://github.com/gliderlabs/docker-alpine/issues/185
+RUN mkdir -p /run/nginx
+
 COPY src/macksnow /usr/src/macksnow
 WORKDIR /usr/src/macksnow
 RUN go build

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN go build
 
 COPY src/tangerine /usr/src/tangerine
 WORKDIR /usr/src/tangerine
-RUN npm install && npm run build && npm run export
+RUN npm install
 
 RUN go get -u github.com/pressly/goose/cmd/goose
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
-FROM ubuntu:20.04
+FROM alpine:latest
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PATH=$PATH:/usr/lib/go-1.14/bin
 ARG AXIOS_BASE_URL=http://localhost/api/v1/
 ENV AXIOS_BASE_URL=$AXIOS_BASE_URL
 
-RUN apt-get update && apt-get install -y \
-    golang-1.14-go \
-    nodejs npm \
+RUN apk add \
+    go \
+    nodejs \
+    npm \
     ruby \
     curl \
     git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN go build
 
 COPY src/tangerine /usr/src/tangerine
 WORKDIR /usr/src/tangerine
-RUN npm install
+RUN npm install && npm run build && npm run export
 
 RUN go get -u github.com/pressly/goose/cmd/goose
 

--- a/src/eclipse/start.sh
+++ b/src/eclipse/start.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-cd /usr/src/tangerine && NUXT_PORT=3000 npm run dev&
+cd /usr/src/tangerine && NUXT_PORT=3000 npm run serve&
 cd /usr/src/macksnow && ./macksnow&
 
 # build

--- a/src/eclipse/start.sh
+++ b/src/eclipse/start.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-cd /usr/src/tangerine && NUXT_PORT=3000 npm run serve&
+cd /usr/src/tangerine && NUXT_PORT=3000 npm run dev&
 cd /usr/src/macksnow && ./macksnow&
 
 # build


### PR DESCRIPTION
herokuの自動デプロイ改善

* [x] ベースイメージをubuntuからalpineに変更した
* [ ] nuxtのbuild && export が最も時間を食っていることを特定した
  - これをやめてdev serverで起動するように変更しようとしたが、herokuのメモリ不足で起動できないことが分かった

ubuntu => alpineでbaseイメージをpullってくるところと、ビルド後に稼働環境にイメージをpushするところが時短できているので多少は改善されているはず...